### PR TITLE
adds s3-cmk storage adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ machine as outlined
 * `bucket` - The bucket you wish to save the file to.
 * `key` - The key or path you wish to save the file to in the given bucket.
 
+## `s3-cmk`
+
+This is a storage option that saves your original .env files in s3 encrypted with a customer master key (CMK).
+Note that with this adapter, you need to have your local credentials file set up on your machine as outlined
+[here](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html#Creating_the_Shared_Credentials_File).
+
+You will need to first create a customer master key as outlined
+[here](http://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html).  Users uploading .env files and
+EC2 instances downloading them need to be configured to have access to the CMK.
+
+### Additional required options
+
+* `region` - The s3 region where the bucket lives.
+* `bucket` - The bucket you wish to save the file to.
+* `key` - The key or path you wish to save the file to in the given bucket.
+* `cmk` - The CMK key-id (`arn:aws:kms:...`) or alias (`alias/AliasName`) to use for encryption.
+
 ## Custom Adapters
 
 If you wish to use a custom adapter, put in the path to your custom adapter in

--- a/lib/storage/adapters/s3-cmk.js
+++ b/lib/storage/adapters/s3-cmk.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var Promise = require('bluebird');
+var fs = require('fs');
+var aws = require('aws-sdk');
+
+exports.download = function(options) {
+
+  aws.config.update({ region: options.region });
+  var s3Client = require('node-s3-encryption-client');
+
+  return getObject()
+    .then(writeLocal);
+
+  function getObject() {
+    return Promise.fromCallback(function(cb) {
+      s3Client.getObject({
+        Bucket: options.bucket,
+        Key: options.key,
+        EncryptionContext: encryptionContext(options),
+      }, cb);
+    })
+      .then(function(data) {
+        return data.Body;
+      });
+  }
+
+  function writeLocal(data) {
+    return Promise.fromCallback(function(cb) {
+      fs.writeFile(options.localPath, data, null, cb);
+    });
+  }
+};
+
+exports.upload = function(options) {
+
+  aws.config.update({ region: options.region });
+  var s3Client = require('node-s3-encryption-client');
+
+  return readLocal()
+    .then(putObject);
+
+  function readLocal() {
+    return Promise.fromCallback(function(cb) {
+      fs.readFile(options.localPath, null, cb);
+    });
+  }
+
+  function putObject(body) {
+    return Promise.fromCallback(function(cb) {
+      s3Client.putObject({
+        Bucket: options.bucket,
+        Key: options.key,
+        Body: body,
+        KmsParams: {
+          KeyId: options.cmk,
+          KeySpec: 'AES_256',
+          EncryptionContext: encryptionContext(options),
+        },
+      }, cb);
+    });
+  }
+
+};
+
+// See: http://docs.aws.amazon.com/kms/latest/developerguide/services-s3.html#s3-encryption-context
+function encryptionContext(options) {
+  return { 'aws:s3:arn': 'arn:aws:s3:::' + options.bucket + '/' + options.name };
+}
+exports.requiredOptions = [ 'region', 'bucket', 'key', 'cmk' ];

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "commander": "^2.9.0",
     "dotenv": "^2.0.0",
     "mkdirp": "^0.5.1",
+    "node-s3-encryption-client": "^0.0.2",
     "object-assign": "^4.0.1",
     "rc": "^1.1.5",
     "string-template": "^1.0.0"


### PR DESCRIPTION
This adapter is similar to the S3 adapter except that the `.env` file is first encrypted client-side before being uploaded to the S3 bucket. This avoid having sensitive information on S3 in plain text.

Inspired by [this article](https://www.promptworks.com/blog/handling-environment-secrets-in-docker-on-the-aws-container-service).